### PR TITLE
Prevent vertical scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ html, body {
   font-family: 'Cutive Mono', monospace;
   font-size: 30px;
   padding: 10px;
-
+  overflow-y: hidden;
 }
 .display {
   text-align: center;


### PR DESCRIPTION
On multiple web browsers (Safari, Firefox, and Chrome tested) you are able to scroll down to see below the webpage. 

`overflow-y: hidden;` will help prevent this.